### PR TITLE
Fix messageDelete when message is null or defined bug

### DIFF
--- a/discord-auditlog.js
+++ b/discord-auditlog.js
@@ -129,6 +129,7 @@ module.exports = function (bot, options) {
 
     // MESSAGE DELETE V12
     bot.on("messageDelete", message => {
+        if (!message) return
         if (message.author.bot === true) return
         if (message.channel.type !== "text") return
         if (debugmode) console.log(`Module: ${description.name} | messageDelete triggered`)


### PR DESCRIPTION
Fixes a bug when the message deleted was created when the bot was not running. 